### PR TITLE
feat: include props and style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-typical",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React Animated typing in ~400 bytes 🐡 of JavaScript.",
   "author": "catalinmiron",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { type, type as loopedType } from "@camwiegert/typical";
 
 import styles from './styles.css'
 
-const Typical = ({ steps, loop, className, wrapper = "p" }) => {
+const Typical = ({ steps, loop, className, wrapper = "p", props, style }) => {
   const typicalRef = useRef(null);
   const Component = wrapper;
   const classNames = [styles.typicalWrapper];
@@ -28,7 +28,7 @@ const Typical = ({ steps, loop, className, wrapper = "p" }) => {
     }
   });
 
-  return <Component ref={typicalRef} className={classNames.join(' ')}/>;
+  return <Component ref={typicalRef} className={classNames.join(' ')} {...props} style={{...style}}/>;
 }
 
 export default memo(Typical)


### PR DESCRIPTION
Add `props` and `style` to forward styling and enable the use of custom components as a wrapper.

Example: Use with Chakra-UI
```
import { Heading } from '@chakra/react'
...
const [primary, secondary] = useToken("colors", ["gray.500", "blue.500"]);
  ...
<Typical
  steps={["Hello", 1000, "Hello world!", 500]}
  loop={Infinity}
  wrapper={Heading}
  props={{
    bgGradient:`linear(to-t, ${primary}, ${secondary})`,
    bgClip:"text"
  }}
  style={{
    fontSize: "5rem"
  }}
/>
```

![example](https://user-images.githubusercontent.com/15649320/123448752-70165d00-d5db-11eb-8577-11078d4cd182.gif)

Closes https://github.com/catalinmiron/react-typical/issues/18
